### PR TITLE
Implement miner redirection OP_CODEs

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -177,6 +177,10 @@ enum opcodetype {
     OP_NOP9 = 0xb8,
     OP_NOP10 = 0xb9,
 
+    // Mark all output values as miner fees
+    OP_MINER_REDIRECT1 = 0xba,
+    OP_MINER_REDIRECT2 = 0xbb,
+
     // The first op_code value after all defined opcodes
     FIRST_UNDEFINED_OP_VALUE,
 

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -70,6 +70,12 @@ typedef enum ScriptError_t {
     SCRIPT_ERR_ILLEGAL_FORKID,
     SCRIPT_ERR_MUST_USE_FORKID,
 
+    /* script contains an OP_MINER_REDIRECTn
+     *
+     * This is an error for incoming transactions, but in blocks this error
+     * will be caught and clear the corresponding output value */
+    SCRIPT_ERR_MINER_REDIRECT,
+
     SCRIPT_ERR_ERROR_COUNT
 } ScriptError;
 


### PR DESCRIPTION
This adds miner redirection of OP_CHECKDATASIG and OP_CHECKDATASIGVERIFY as per [Craig Wright's announcement](https://medium.com/@craig_10243/bitcoin-is-all-about-incentives-72894518f6b5)

Tests and spec are still missing as I think this may need discussion first but I am happy to add them.


This works by adding OP_MINER_REDIRECT1 and OP_MINER_REDIRECT2. These OPCODEs,
match OP_CHECKDATASIG and OP_CHECKDATASIGVERIFY in other implementation and will cause corresponding output values to be redirected to the miner.

Note that this only redirects funds on *spending* the output which seems to make more sense. 

Note that currently only the output with the same index as the input containing the miner redirect will be send to the miner. Otherwise constructions with SIGHASH_ANYONECANPAY | SIGHASH_SINGLE would become unusable.

