### PR TITLE
Liberate OP_RETURN

### DIFF
--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -430,15 +430,6 @@ Node relay options:
 .IP
 Equivalent bytes per sigop in transactions for relay and mining
 (default: 20)
-.HP
-\fB\-datacarrier\fR
-.IP
-Relay and mine data carrier transactions (default: 1)
-.HP
-\fB\-datacarriersize\fR
-.IP
-Maximum size of data in data carrier transactions we relay and mine
-(pre\-fork default: 83, post\-fork default: 223)
 .PP
 Block creation options:
 .HP

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -814,15 +814,6 @@ std::string HelpMessage(HelpMessageMode mode) {
                        strprintf(_("Equivalent bytes per sigop in transactions "
                                    "for relay and mining (default: %u)"),
                                  DEFAULT_BYTES_PER_SIGOP));
-    strUsage += HelpMessageOpt(
-        "-datacarrier",
-        strprintf(_("Relay and mine data carrier transactions (default: %d)"),
-                  DEFAULT_ACCEPT_DATACARRIER));
-    strUsage += HelpMessageOpt(
-        "-datacarriersize",
-        strprintf(_("Maximum size of data in data carrier transactions we "
-                    "relay and mine (default: %u)"),
-                  MAX_OP_RETURN_RELAY));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt(
@@ -1610,8 +1601,6 @@ bool AppInitParameterInteraction(Config &config) {
 
     fIsBareMultisigStd =
         gArgs.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
-    fAcceptDatacarrier =
-        gArgs.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
 
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(gArgs.GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -39,16 +39,6 @@ bool IsStandard(const CScript &scriptPubKey, txnouttype &whichType) {
         // Support up to x-of-3 multisig txns as standard
         if (n < 1 || n > 3) return false;
         if (m < 1 || m > n) return false;
-    } else if (whichType == TX_NULL_DATA) {
-        if (!fAcceptDatacarrier) {
-            return false;
-        }
-
-        unsigned nMaxDatacarrierBytes =
-            gArgs.GetArg("-datacarriersize", MAX_OP_RETURN_RELAY);
-        if (scriptPubKey.size() > nMaxDatacarrierBytes) {
-            return false;
-        }
     }
 
     return whichType != TX_NONSTANDARD;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -87,7 +87,6 @@ bool IsStandardTx(const CTransaction &tx, std::string &reason) {
         }
     }
 
-    unsigned int nDataOut = 0;
     txnouttype whichType;
     for (const CTxOut &txout : tx.vout) {
         if (!::IsStandard(txout.scriptPubKey, whichType)) {
@@ -96,7 +95,7 @@ bool IsStandardTx(const CTransaction &tx, std::string &reason) {
         }
 
         if (whichType == TX_NULL_DATA) {
-            nDataOut++;
+            // Avoid IsDust test below
         } else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
             reason = "bare-multisig";
             return false;
@@ -104,12 +103,6 @@ bool IsStandardTx(const CTransaction &tx, std::string &reason) {
             reason = "dust";
             return false;
         }
-    }
-
-    // only one OP_RETURN txout is permitted
-    if (nDataOut > 1) {
-        reason = "multi-op-return";
-        return false;
     }
 
     return true;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -12,8 +12,6 @@
 
 typedef std::vector<uint8_t> valtype;
 
-bool fAcceptDatacarrier = DEFAULT_ACCEPT_DATACARRIER;
-
 CScriptID::CScriptID(const CScript &in)
     : uint160(Hash160(in.begin(), in.end())) {}
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -13,8 +13,6 @@
 
 #include <cstdint>
 
-static const bool DEFAULT_ACCEPT_DATACARRIER = true;
-
 class CKeyID;
 class CScript;
 
@@ -25,10 +23,6 @@ public:
     CScriptID(const CScript &in);
     CScriptID(const uint160 &in) : uint160(in) {}
 };
-
-//!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
-static const unsigned int MAX_OP_RETURN_RELAY = 223;
-extern bool fAcceptDatacarrier;
 
 /**
  * Mandatory script verification flags that all new blocks must comply with for

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -645,66 +645,15 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
     t.vout[0].scriptPubKey = CScript() << OP_1;
     BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
 
-    // MAX_OP_RETURN_RELAY-byte TX_NULL_DATA (standard)
-    t.vout[0].scriptPubKey =
-        CScript() << OP_RETURN
-                  << ParseHex("646578784062697477617463682e636f2092c558ed52c56d"
-                              "8dd14ca76226bc936a84820d898443873eb03d8854b21fa3"
-                              "952b99a2981873e74509281730d78a21786d34a38bd1ebab"
-                              "822fad42278f7f4420db6ab1fd2b6826148d4f73bb41ec2d"
-                              "40a6d5793d66e17074a0c56a8a7df21062308f483dd6e38d"
-                              "53609d350038df0a1b2a9ac8332016e0b904f66880dd0108"
-                              "81c4e8074cce8e4ad6c77cb3460e01bf0e7e811b5f945f83"
-                              "732ba6677520a893d75d9a966cb8f85dc301656b1635c631"
-                              "f5d00d4adf73f2dd112ca75cf19754651909becfbe65aed1"
-                              "3afb2ab8");
-    BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
-    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
-
-    // MAX_OP_RETURN_RELAY+1-byte TX_NULL_DATA (non-standard)
-    t.vout[0].scriptPubKey =
-        CScript() << OP_RETURN
-                  << ParseHex("646578784062697477617463682e636f2092c558ed52c56d"
-                              "8dd14ca76226bc936a84820d898443873eb03d8854b21fa3"
-                              "952b99a2981873e74509281730d78a21786d34a38bd1ebab"
-                              "822fad42278f7f4420db6ab1fd2b6826148d4f73bb41ec2d"
-                              "40a6d5793d66e17074a0c56a8a7df21062308f483dd6e38d"
-                              "53609d350038df0a1b2a9ac8332016e0b904f66880dd0108"
-                              "81c4e8074cce8e4ad6c77cb3460e01bf0e7e811b5f945f83"
-                              "732ba6677520a893d75d9a966cb8f85dc301656b1635c631"
-                              "f5d00d4adf73f2dd112ca75cf19754651909becfbe65aed1"
-                              "3afb2ab800");
-    BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-
     /**
-     * Check when a custom value is used for -datacarriersize .
+     * Check large OP_RETURN payloads are standard.
      */
-    unsigned newMaxSize = 90;
-    gArgs.ForceSetArg("-datacarriersize", std::to_string(newMaxSize));
+    std::string payload(5000, '1');
 
-    // Max user provided payload size is standard
     t.vout[0].scriptPubKey =
         CScript() << OP_RETURN
-                  << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909"
-                              "a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548"
-                              "271967f1a67130b7105cd6a828e03909a67962e0ea1f61de"
-                              "b649f6bc3f4cef3877696e64657878");
-    BOOST_CHECK_EQUAL(t.vout[0].scriptPubKey.size(), newMaxSize);
+                  << ParseHex(payload);
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
-
-    // Max user provided payload size + 1 is non-standard
-    t.vout[0].scriptPubKey =
-        CScript() << OP_RETURN
-                  << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909"
-                              "a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548"
-                              "271967f1a67130b7105cd6a828e03909a67962e0ea1f61de"
-                              "b649f6bc3f4cef3877696e6465787800");
-    BOOST_CHECK_EQUAL(t.vout[0].scriptPubKey.size(), newMaxSize + 1);
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-
-    // Clear custom confirguration.
-    gArgs.ClearArg("-datacarriersize");
 
     // Data payload can be encoded in any way...
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("");

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -733,7 +733,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
-    // Only one TX_NULL_DATA permitted in all cases
+    // More than one TX_NULL_DATA permitted
     t.vout.resize(2);
     t.vout[0].scriptPubKey =
         CScript() << OP_RETURN
@@ -743,18 +743,18 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
         CScript() << OP_RETURN
                   << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909"
                               "a67962e0ea1f61deb649f6bc3f4cef38");
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
     t.vout[0].scriptPubKey =
         CScript() << OP_RETURN
                   << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909"
                               "a67962e0ea1f61deb649f6bc3f4cef38");
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Make multiple OP_RETURN outputs standard,  and place no standardness restrictions on their size