### PR TITLE
array.tostring deprecated alias for tobytes

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -115,7 +115,7 @@ def all_interfaces():
             max_possible *= 2
         else:
             break
-    namestr = names.tostring()
+    namestr = names.tobytes()
     return [(namestr[i:i + 16].split(b'\0', 1)[0],
              socket.inet_ntoa(namestr[i + 20:i + 24]))
             for i in range(0, outbytes, struct_size)]


### PR DESCRIPTION
According to python, array tostring method was renamed to tobytes.
https://docs.python.org/3.2/library/array.html

This console output shows the deprecation warning that causes test to fail in python 3.7.3
```
fullcycle@Oracle:~/bitcoin-sv/src$ alias python="python3.7"
fullcycle@Oracle:~/bitcoin-sv/src$ python -V
Python 3.7.3
fullcycle@Oracle:~/bitcoin-sv/src$ cd ..
fullcycle@Oracle:~/bitcoin-sv$ python test/functional/test_runner.py rpcbind_test.py
Temporary test directory at /tmp/bitcoin_test_runner_20190521_112220
WARNING! There is already a bitcoind process running on this system. Tests may fail unexpectedly due to resource contention!
.................................................
rpcbind_test.py failed, Duration: 25 s

stdout:
2019-05-21 18:22:20.826000 TestFramework (INFO): Initializing test directory /tmp/bitcoin_test_runner_20190521_112220/rpcbind_test_397
2019-05-21 18:22:20.838000 TestFramework (INFO): Using interface 192.168.1.170 for testing
2019-05-21 18:22:20.838000 TestFramework (INFO): Bind test for []
2019-05-21 18:22:23.481000 TestFramework (INFO): Bind test for []
2019-05-21 18:22:25.950000 TestFramework (INFO): Bind test for ['127.0.0.1']
2019-05-21 18:22:28.368000 TestFramework (INFO): Bind test for ['127.0.0.1:32171']
2019-05-21 18:22:30.835000 TestFramework (INFO): Bind test for ['127.0.0.1:32171', '127.0.0.1:32172']
2019-05-21 18:22:33.254000 TestFramework (INFO): Bind test for ['[::1]']
2019-05-21 18:22:35.671000 TestFramework (INFO): Bind test for ['127.0.0.1', '[::1]']
2019-05-21 18:22:38.138000 TestFramework (INFO): Bind test for ['192.168.1.170']
2019-05-21 18:22:40.555000 TestFramework (INFO): Allow IP test for 192.168.1.170:19176
2019-05-21 18:22:42.973000 TestFramework (INFO): Allow IP test for 192.168.1.170:19176
2019-05-21 18:22:43.232000 TestFramework (INFO): Stopping nodes
2019-05-21 18:22:45.388000 TestFramework (INFO): Cleaning up /tmp/bitcoin_test_runner_20190521_112220/rpcbind_test_397 on exit
2019-05-21 18:22:45.389000 TestFramework (INFO): Tests successful


stderr:
/home/fullcycle/bitcoin-sv/test/functional/rpcbind_test.py:61: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  for name, ip in all_interfaces():



TEST            | STATUS    | DURATION

rpcbind_test.py | ✖ Failed  | 25 s

ALL             | ✖ Failed  | 25 s (accumulated) 
Runtime: 25 s

```