### PR TITLE
Avoid univalue.h compile errors on macOS.

### DIFF
--- a/src/univalue/Makefile.am
+++ b/src/univalue/Makefile.am
@@ -19,7 +19,7 @@ libunivalue_la_SOURCES = \
 libunivalue_la_LDFLAGS = \
 	-version-info $(LIBUNIVALUE_CURRENT):$(LIBUNIVALUE_REVISION):$(LIBUNIVALUE_AGE) \
 	-no-undefined
-libunivalue_la_CXXFLAGS = -I$(top_srcdir)/include
+libunivalue_la_CXXFLAGS = -I$(top_srcdir)/include -std=c++11
 
 TESTS = test/object test/unitester test/no_nul
 
@@ -40,22 +40,22 @@ TEST_DATA_DIR=test
 
 test_unitester_SOURCES = test/unitester.cpp
 test_unitester_LDADD = libunivalue.la
-test_unitester_CXXFLAGS = -I$(top_srcdir)/include -DJSON_TEST_SRC=\"$(srcdir)/$(TEST_DATA_DIR)\"
+test_unitester_CXXFLAGS = -I$(top_srcdir)/include -DJSON_TEST_SRC=\"$(srcdir)/$(TEST_DATA_DIR)\"  -std=c++11
 test_unitester_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
 test_test_json_SOURCES = test/test_json.cpp
 test_test_json_LDADD = libunivalue.la
-test_test_json_CXXFLAGS = -I$(top_srcdir)/include
+test_test_json_CXXFLAGS = -I$(top_srcdir)/include  -std=c++11
 test_test_json_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
 test_no_nul_SOURCES = test/no_nul.cpp
 test_no_nul_LDADD = libunivalue.la
-test_no_nul_CXXFLAGS = -I$(top_srcdir)/include
+test_no_nul_CXXFLAGS = -I$(top_srcdir)/include  -std=c++11
 test_no_nul_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
 test_object_SOURCES = test/object.cpp
 test_object_LDADD = libunivalue.la
-test_object_CXXFLAGS = -I$(top_srcdir)/include
+test_object_CXXFLAGS = -I$(top_srcdir)/include  -std=c++11
 test_object_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
 TEST_FILES = \

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -25,30 +25,30 @@ public:
 
     UniValue() : m_JSONParseDepth (DEFAULT_JSON_DEPTH) { typ = VNULL; }
     UniValue(UniValue::VType initialType, const std::string& initialStr = "")
-        : m_JSONParseDepth(2048)
+        : m_JSONParseDepth(DEFAULT_JSON_DEPTH)
     {
         typ = initialType;
         val = initialStr;
     }
-    UniValue(uint64_t val_) : m_JSONParseDepth (2048) {
+    UniValue(uint64_t val_) : m_JSONParseDepth (DEFAULT_JSON_DEPTH) {
         setInt(val_);
     }
-    UniValue(int64_t val_) : m_JSONParseDepth (2048) {
+    UniValue(int64_t val_) : m_JSONParseDepth (DEFAULT_JSON_DEPTH) {
         setInt(val_);
     }
-    UniValue(bool val_) : m_JSONParseDepth (2048) {
+    UniValue(bool val_) : m_JSONParseDepth (DEFAULT_JSON_DEPTH) {
         setBool(val_);
     }
-    UniValue(int val_) : m_JSONParseDepth (2048) {
+    UniValue(int val_) : m_JSONParseDepth (DEFAULT_JSON_DEPTH) {
         setInt(val_);
     }
-    UniValue(double val_) : m_JSONParseDepth (2048) {
+    UniValue(double val_) : m_JSONParseDepth (DEFAULT_JSON_DEPTH) {
         setFloat(val_);
     }
-    UniValue(const std::string& val_) : m_JSONParseDepth (2048) {
+    UniValue(const std::string& val_) : m_JSONParseDepth (DEFAULT_JSON_DEPTH) {
         setStr(val_);
     }
-    UniValue(const char *val_) : m_JSONParseDepth (2048) {
+    UniValue(const char *val_) : m_JSONParseDepth (DEFAULT_JSON_DEPTH) {
         std::string s(val_);
         setStr(s);
     }


### PR DESCRIPTION
Related to #18.

Compilation on macOS fails with the following error messages:

```
In file included from test/object.cpp:12:
./include/univalue.h:20:1: error: unknown type name 'constexpr'
constexpr int DEFAULT_JSON_DEPTH (2048);
^
./include/univalue.h:20:11: error: expected unqualified-id
constexpr int DEFAULT_JSON_DEPTH (2048);
          ^
./include/univalue.h:26:36: error: use of undeclared identifier 'DEFAULT_JSON_DEPTH'
    UniValue() : m_JSONParseDepth (DEFAULT_JSON_DEPTH) { typ = VNULL; }
```

It seems that `clang` uses an older C++ standard by default and I was able to get around the issue using a compile flag that changes that. 

While looking around I also noticed that it might make sense to use the constexpr in question in a few additional places. 