### PR TITLE
Fix duplicate misbehaving message for sendheaders.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1897,10 +1897,10 @@ static void ProcessSendHeadersMessage(const CNodePtr& pfrom)
     CNodeState* state = State(pfrom->GetId());
     if(state != nullptr) {
         if(state->fPreferHeaders) {
-            // This message should only be received once. If its already set it might 
+            // This message should only be received once. If its already set it might
             // indicate a misbehaving node. Increase the banscore
-            Misbehaving(pfrom, 1, "Invalid Header activity");
-            LogPrintf("Peer %d showing increased activity in message header transmission\n",pfrom->id);
+            Misbehaving(pfrom, 1, "Invalid SendHeaders activity");
+            LogPrintf("Peer %d sent SendHeaders more than once\n",pfrom->id);
         }
         else {
             state->fPreferHeaders = true;


### PR DESCRIPTION
This message was the same as the other invalid header frequency misbehaving message so I updated it to mention the "sendheaders" message it is related to. This makes it more clear why a node is considered to be misbehaving.