### PR TITLE
Get compiles and builds working on MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,11 +473,12 @@ case $host in
          openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
          bdb_prefix=`$BREW --prefix berkeley-db4 2>/dev/null`
          if test x$openssl_prefix != x; then
+           CPPFLAGS="$CPPFLAGS -I$openssl_prefix/include"
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
          fi
          if test x$bdb_prefix != x; then
-           CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
+           BDB_CFLAGS="-I$bdb_prefix/include"
            LIBS="$LIBS -L$bdb_prefix/lib"
          fi
        fi

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -111,16 +111,16 @@ static int verify_script(const Config& config, const uint8_t* scriptPubKey,
 }
 
 int bitcoinconsensus_verify_script_with_amount(
+    const Config& config,
     const uint8_t *scriptPubKey, unsigned int scriptPubKeyLen, int64_t amount,
     const uint8_t *txTo, unsigned int txToLen, unsigned int nIn,
     unsigned int flags, bitcoinconsensus_error *err) {
     Amount am(amount);
-    const Config& config = GlobalConfig::GetConfig();
     return ::verify_script(config, scriptPubKey, scriptPubKeyLen, am, txTo, txToLen,
                            nIn, flags, err);
 }
 
-int bitcoinconsensus_verify_script(const uint8_t *scriptPubKey,
+int bitcoinconsensus_verify_script(const Config& config, const uint8_t *scriptPubKey,
                                    unsigned int scriptPubKeyLen,
                                    const uint8_t *txTo, unsigned int txToLen,
                                    unsigned int nIn, unsigned int flags,
@@ -131,7 +131,6 @@ int bitcoinconsensus_verify_script(const uint8_t *scriptPubKey,
     }
 
     Amount am(0);
-    const Config& config = GlobalConfig::GetConfig();
     return ::verify_script(config, scriptPubKey, scriptPubKeyLen, am, txTo, txToLen,
                            nIn, flags, err);
 }

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -69,16 +69,20 @@ enum {
         bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY,
 };
 
+class Config;
+
 /// Returns 1 if the input nIn of the serialized transaction pointed to by txTo
 /// correctly spends the scriptPubKey pointed to by scriptPubKey under the
 /// additional constraints specified by flags.
 /// If not nullptr, err will contain an error/success code for the operation
 EXPORT_SYMBOL int bitcoinconsensus_verify_script(
+    const Config& config,
     const uint8_t *scriptPubKey, unsigned int scriptPubKeyLen,
     const uint8_t *txTo, unsigned int txToLen, unsigned int nIn,
     unsigned int flags, bitcoinconsensus_error *err);
 
 EXPORT_SYMBOL int bitcoinconsensus_verify_script_with_amount(
+    const Config& config,
     const uint8_t *scriptPubKey, unsigned int scriptPubKeyLen, int64_t amount,
     const uint8_t *txTo, unsigned int txToLen, unsigned int nIn,
     unsigned int flags, bitcoinconsensus_error *err);

--- a/src/univalue/Makefile.am
+++ b/src/univalue/Makefile.am
@@ -19,7 +19,7 @@ libunivalue_la_SOURCES = \
 libunivalue_la_LDFLAGS = \
 	-version-info $(LIBUNIVALUE_CURRENT):$(LIBUNIVALUE_REVISION):$(LIBUNIVALUE_AGE) \
 	-no-undefined
-libunivalue_la_CXXFLAGS = -I$(top_srcdir)/include
+libunivalue_la_CXXFLAGS = -I$(top_srcdir)/include -std=c++17
 
 TESTS = test/object test/unitester test/no_nul
 


### PR DESCRIPTION
This patch is against dev-Genesis-beta and enables bitcoin-sv to compile and build on MacOS.   Perhaps because of MacOS use of gmake and clang it raises issues that apparently you don't see on Linux.

- configure.ac: add include path and fix finding libs (this block is MacOS-specific)

- libunivalue: this uses C++17 features so must be compiled as such

- libbitcoinconsensus: since https://github.com/bitcoin-sv/bitcoin-sv/commit/7953ca64c5829f48c4369b162b12612f8ee5451b the code calls **GlobalConfig::GetConfig()**.  This is problematic because that is in _config.cpp_ which is not part of libbitcoinconsensus and the external dependency is not linked but the two functions calling it are exported.  It's unclear to me how this ever worked on Linux.  Fix it by having the caller pass in the config, and call **GlobalConfig::GetConfig()** itself if necessary.  Note that the only caller is test code testing their functionality; so unless the functions **verify_script_with_amount()** and **verify_script()** are deliberately exported in order to be used in non-public code outside the repo, then they could simply be removed entirely.

Please merge these fixes for Genesis - it will be the first release that works out-of-the-box on MacOS, including with various configure options like --disable-wallet which I have also tested.