### PR TITLE
Feature/rpm for centos 7

### DIFF
--- a/contrib/rpm/bitcoin.spec
+++ b/contrib/rpm/bitcoin.spec
@@ -1,78 +1,71 @@
-%define bdbv 4.8.30
-%global selinux_variants mls strict targeted
+# %global selinux_variants mls strict targeted
 
-Name:		bitcoin
-Version:	0.12.0
-Release:	2%{?dist}
+Name:		bitcoin-sv
+Version:	1.0.1
+Release:	1%{?dist}
 Summary:	Peer to Peer Cryptographic Currency
 
 Group:		Applications/System
 License:	MIT
-URL:		https://bitcoin.org/
-Source0:	https://bitcoin.org/bin/bitcoin-core-%{version}/bitcoin-%{version}.tar.gz
-Source1:	http://download.oracle.com/berkeley-db/db-%{bdbv}.NC.tar.gz
+URL:		https://bitcoinsv.io
+Source0:	https://github.com/bitcoin-sv/bitcoin-sv/archive/v%{version}.tar.gz
 
-Source10:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/debian/examples/bitcoin.conf
+Source10:	https://raw.githubusercontent.com/bitcoin-sv/bitcoin-sv/v%{version}/contrib/debian/examples/bitcoin.conf
 
-#man pages
-Source20:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/doc/man/bitcoind.1
-Source21:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/doc/man/bitcoin-cli.1
+### SELINUX PART REQUIRES FURTHER WORK
+# #selinux
+# Source30:	https://raw.githubusercontent.com/bitcoin-sv/bitcoin-sv/v%{version}/contrib/rpm/bitcoin-sv.te
+# # Source31 - what about bitcoin-sv-tx and bench_bitcoin-sv ???
+# Source31:	https://raw.githubusercontent.com/bitcoin-sv/bitcoin-sv/v%{version}/contrib/rpm/bitcoin-sv.fc
+# Source32:	https://raw.githubusercontent.com/bitcoin-sv/bitcoin-sv/v%{version}/contrib/rpm/bitcoin-sv.if
 
-#selinux
-Source30:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/rpm/bitcoin.te
-# Source31 - what about bitcoin-tx and bench_bitcoin ???
-Source31:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/rpm/bitcoin.fc
-Source32:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/rpm/bitcoin.if
+Source100:	https://bitbay.net/helpdesk/bitcoin-cryptocurrencies/bitcoin-sv-bsv/bsv1024.png
 
-Source100:	https://upload.wikimedia.org/wikipedia/commons/4/46/Bitcoin.svg
-
-%if 0%{?_use_libressl:1}
-BuildRequires:	libressl-devel
-%else
 BuildRequires:	openssl-devel
-%endif
-BuildRequires:	boost-devel
+BuildRequires:	boost169-devel
 BuildRequires:	miniupnpc-devel
 BuildRequires:	autoconf automake libtool
 BuildRequires:	libevent-devel
-
-
-Patch0:		bitcoin-0.12.0-libressl.patch
-
+BuildRequires:	which
+BuildRequires:	centos-release-scl
+BuildRequires:	devtoolset-7-gcc
+BuildRequires:	devtoolset-7-gcc-c++
+BuildRequires:	libdb-cxx-devel
+BuildRequires:	libdb-devel
 
 %description
-Bitcoin is a digital cryptographic currency that uses peer-to-peer technology to
+bitcoin-sv is a digital cryptographic currency that uses peer-to-peer technology to
 operate with no central authority or banks; managing transactions and the
-issuing of bitcoins is carried out collectively by the network.
+issuing of bitcoin-svs is carried out collectively by the network.
 
 %package libs
-Summary:	Bitcoin shared libraries
+Summary:	bitcoin-sv shared libraries
 Group:		System Environment/Libraries
 
 %description libs
-This package provides the bitcoinconsensus shared libraries. These libraries
+This package provides the bitcoin-svconsensus shared libraries. These libraries
 may be used by third party software to provide consensus verification
 functionality.
 
 Unless you know need this package, you probably do not.
 
 %package devel
-Summary:	Development files for bitcoin
+Summary:	Development files for bitcoin-sv
 Group:		Development/Libraries
 Requires:	%{name}-libs = %{version}-%{release}
 
 %description devel
 This package contains the header files and static library for the
-bitcoinconsensus shared library. If you are developing or compiling software
+bitcoin-svconsensus shared library. If you are developing or compiling software
 that wants to link against that library, then you need this package installed.
 
 Most people do not need this package installed.
 
 %package server
-Summary:	The bitcoin daemon
+Summary:	The bitcoin-sv daemon
 Group:		System Environment/Daemons
-Requires:	bitcoin-utils = %{version}-%{release}
-Requires:	selinux-policy policycoreutils-python
+Requires:	bitcoin-sv-utils = %{version}-%{release}
+Requires:	selinux-policy policycoreutils-python libdb libdb-cxx
 Requires(pre):	shadow-utils
 Requires(post):	%{_sbindir}/semodule %{_sbindir}/restorecon %{_sbindir}/fixfiles %{_sbindir}/sestatus
 Requires(postun):	%{_sbindir}/semodule %{_sbindir}/restorecon %{_sbindir}/fixfiles %{_sbindir}/sestatus
@@ -81,100 +74,104 @@ BuildRequires:	checkpolicy
 BuildRequires:	%{_datadir}/selinux/devel/Makefile
 
 %description server
-This package provides a stand-alone bitcoin-core daemon. For most users, this
+This package provides a stand-alone bitcoin-sv-core daemon. For most users, this
 package is only needed if they need a full-node without the graphical client.
 
 Some third party wallet software will want this package to provide the actual
-bitcoin-core node they use to connect to the network.
+bitcoin-sv-core node they use to connect to the network.
 
-If you use the graphical bitcoin-core client then you almost certainly do not
+If you use the graphical bitcoin-sv-core client then you almost certainly do not
 need this package.
 
 %package utils
-Summary:	Bitcoin utilities
+Summary:	bitcoin-sv utilities
 Group:		Applications/System
 
 %description utils
 This package provides several command line utilities for interacting with a
-bitcoin-core daemon.
+bitcoin-sv-core daemon.
 
-The bitcoin-cli utility allows you to communicate and control a bitcoin daemon
-over RPC, the bitcoin-tx utility allows you to create a custom transaction, and
-the bench_bitcoin utility can be used to perform some benchmarks.
+The bitcoin-sv-cli utility allows you to communicate and control a bitcoin-sv daemon
+over RPC, the bitcoin-sv-tx utility allows you to create a custom transaction, and
+the bench_bitcoin-sv utility can be used to perform some benchmarks.
 
-This package contains utilities needed by the bitcoin-server package.
+This package contains utilities needed by the bitcoin-sv-server package.
 
 
 %prep
 %setup -q
-%patch0 -p1 -b .libressl
-cp -p %{SOURCE10} ./bitcoin.conf.example
-tar -zxf %{SOURCE1}
-cp -p db-%{bdbv}.NC/LICENSE ./db-%{bdbv}.NC-LICENSE
-mkdir db4 SELinux
-cp -p %{SOURCE30} %{SOURCE31} %{SOURCE32} SELinux/
+cp -p %{SOURCE10} ./bitcoin-sv.conf.example
+mkdir db4
+#mkdir SELinux - selinux support requires further work
+#cp -p %{SOURCE30} %{SOURCE31} %{SOURCE32} SELinux/
 
 
 %build
+. /opt/rh/devtoolset-7/enable
 CWD=`pwd`
-cd db-%{bdbv}.NC/build_unix/
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${CWD}/db4
-make install
-cd ../..
 
 ./autogen.sh
-%configure LDFLAGS="-L${CWD}/db4/lib/" CPPFLAGS="-I${CWD}/db4/include/" --with-miniupnpc --enable-glibc-back-compat %{buildargs}
+%configure CPPFLAGS="-I/usr/include/boost169" --with-miniupnpc --enable-glibc-back-compat --with-boost-libdir=/usr/lib64/boost169 %{buildargs}
 make %{?_smp_mflags}
 
-pushd SELinux
-for selinuxvariant in %{selinux_variants}; do
-	make NAME=${selinuxvariant} -f %{_datadir}/selinux/devel/Makefile
-	mv bitcoin.pp bitcoin.pp.${selinuxvariant}
-	make NAME=${selinuxvariant} -f %{_datadir}/selinux/devel/Makefile clean
-done
-popd
+# pushd SELinux
+# for selinuxvariant in %{selinux_variants}; do
+# 	make NAME=${selinuxvariant} -f %{_datadir}/selinux/devel/Makefile
+# 	mv bitcoin-sv.pp bitcoin-sv.pp.${selinuxvariant}
+# 	make NAME=${selinuxvariant} -f %{_datadir}/selinux/devel/Makefile clean
+# done
+# popd
 
 
 %install
 make install DESTDIR=%{buildroot}
 
 mkdir -p -m755 %{buildroot}%{_sbindir}
-mv %{buildroot}%{_bindir}/bitcoind %{buildroot}%{_sbindir}/bitcoind
+mv %{buildroot}%{_bindir}/bitcoind %{buildroot}%{_sbindir}/bitcoin-svd
+mv %{buildroot}%{_bindir}/bitcoin-cli %{buildroot}%{_bindir}/bitcoin-sv-cli
+mv %{buildroot}%{_bindir}/bitcoin-tx %{buildroot}%{_bindir}/bitcoin-sv-tx
+mv %{buildroot}%{_bindir}/bench_bitcoin %{buildroot}%{_bindir}/bench_bitcoin-sv
+mv %{buildroot}%{_bindir}/bitcoin-miner %{buildroot}%{_bindir}/bitcoin-sv-miner
+mv %{buildroot}%{_bindir}/bitcoin-seeder %{buildroot}%{_bindir}/bitcoin-sv-seeder
+# mv %{buildroot}%{_mandir}/man1/bitcoin-cli.1.gz %{buildroot}%{_mandir}/man1/bitcoin-sv-cli.1.gz
+# mv %{buildroot}%{_mandir}/man1/bitcoin-tx.1.gz %{buildroot}%{_mandir}/man1/bitcoin-sv-tx.1.gz
+# mv %{buildroot}%{_mandir}/man1/bitcoind.1.gz %{buildroot}%{_mandir}/man1/bitcoin-svd.1.gz
+
 
 # systemd stuff
 mkdir -p %{buildroot}%{_tmpfilesdir}
-cat <<EOF > %{buildroot}%{_tmpfilesdir}/bitcoin.conf
-d /run/bitcoind 0750 bitcoin bitcoin -
+cat <<EOF > %{buildroot}%{_tmpfilesdir}/bitcoin-sv.conf
+d /run/bitcoin-svd 0750 bitcoin-sv bitcoin-sv -
 EOF
-touch -a -m -t 201504280000 %{buildroot}%{_tmpfilesdir}/bitcoin.conf
+touch -a -m -t 201504280000 %{buildroot}%{_tmpfilesdir}/bitcoin-sv.conf
 
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
-cat <<EOF > %{buildroot}%{_sysconfdir}/sysconfig/bitcoin
-# Provide options to the bitcoin daemon here, for example
+cat <<EOF > %{buildroot}%{_sysconfdir}/sysconfig/bitcoin-sv
+# Provide options to the bitcoin-sv daemon here, for example
 # OPTIONS="-testnet -disable-wallet"
 
 OPTIONS=""
 
 # System service defaults.
 # Don't change these unless you know what you're doing.
-CONFIG_FILE="%{_sysconfdir}/bitcoin/bitcoin.conf"
-DATA_DIR="%{_localstatedir}/lib/bitcoin"
-PID_FILE="/run/bitcoind/bitcoind.pid"
+CONFIG_FILE="%{_sysconfdir}/bitcoin-sv/bitcoin-sv.conf"
+DATA_DIR="%{_localstatedir}/lib/bitcoin-sv"
+PID_FILE="/run/bitcoin-svd/bitcoin-svd.pid"
 EOF
-touch -a -m -t 201504280000 %{buildroot}%{_sysconfdir}/sysconfig/bitcoin
+touch -a -m -t 201504280000 %{buildroot}%{_sysconfdir}/sysconfig/bitcoin-sv
 
 mkdir -p %{buildroot}%{_unitdir}
-cat <<EOF > %{buildroot}%{_unitdir}/bitcoin.service
+cat <<EOF > %{buildroot}%{_unitdir}/bitcoin-sv.service
 [Unit]
-Description=Bitcoin daemon
+Description=bitcoin-sv daemon
 After=syslog.target network.target
 
 [Service]
 Type=forking
-ExecStart=%{_sbindir}/bitcoind -daemon -conf=\${CONFIG_FILE} -datadir=\${DATA_DIR} -pid=\${PID_FILE} \$OPTIONS
-EnvironmentFile=%{_sysconfdir}/sysconfig/bitcoin
-User=bitcoin
-Group=bitcoin
+ExecStart=%{_sbindir}/bitcoin-svd -daemon -conf=\${CONFIG_FILE} -datadir=\${DATA_DIR} -pid=\${PID_FILE} \$OPTIONS
+EnvironmentFile=%{_sysconfdir}/sysconfig/bitcoin-sv
+User=bitcoin-sv
+Group=bitcoin-sv
 
 Restart=on-failure
 PrivateTmp=true
@@ -186,79 +183,73 @@ StartLimitBurst=5
 [Install]
 WantedBy=multi-user.target
 EOF
-touch -a -m -t 201504280000 %{buildroot}%{_unitdir}/bitcoin.service
+touch -a -m -t 201504280000 %{buildroot}%{_unitdir}/bitcoin-sv.service
 #end systemd stuff
 
-mkdir %{buildroot}%{_sysconfdir}/bitcoin
-mkdir -p %{buildroot}%{_localstatedir}/lib/bitcoin
+mkdir %{buildroot}%{_sysconfdir}/bitcoin-sv
+mkdir -p %{buildroot}%{_localstatedir}/lib/bitcoin-sv
 
-#SELinux
-for selinuxvariant in %{selinux_variants}; do
-	install -d %{buildroot}%{_datadir}/selinux/${selinuxvariant}
-	install -p -m 644 SELinux/bitcoin.pp.${selinuxvariant} %{buildroot}%{_datadir}/selinux/${selinuxvariant}/bitcoin.pp
-done
-
-# man pages
-install -D -p %{SOURCE20} %{buildroot}%{_mandir}/man1/bitcoind.1
-install -p %{SOURCE21} %{buildroot}%{_mandir}/man1/bitcoin-cli.1
+# #SELinux
+# for selinuxvariant in %{selinux_variants}; do
+# 	install -d %{buildroot}%{_datadir}/selinux/${selinuxvariant}
+# 	install -p -m 644 SELinux/bitcoin-sv.pp.${selinuxvariant} %{buildroot}%{_datadir}/selinux/${selinuxvariant}/bitcoin-sv.pp
+# done
 
 # nuke these, we do extensive testing of binaries in %%check before packaging
 rm -f %{buildroot}%{_bindir}/test_*
 
 %check
 make check
-srcdir=src test/bitcoin-util-test.py
-test/functional/test_runner.py --extended
 
 %post libs -p /sbin/ldconfig
 
 %postun libs -p /sbin/ldconfig
 
 %pre server
-getent group bitcoin >/dev/null || groupadd -r bitcoin
-getent passwd bitcoin >/dev/null ||
-	useradd -r -g bitcoin -d /var/lib/bitcoin -s /sbin/nologin \
-	-c "Bitcoin wallet server" bitcoin
+getent group bitcoin-sv >/dev/null || groupadd -r bitcoin-sv
+getent passwd bitcoin-sv >/dev/null ||
+	useradd -r -g bitcoin-sv -d /var/lib/bitcoin-sv -s /sbin/nologin \
+	-c "bitcoin-sv wallet server" bitcoin-sv
 exit 0
 
 %post server
-%systemd_post bitcoin.service
-# SELinux
-if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
-for selinuxvariant in %{selinux_variants}; do
-	%{_sbindir}/semodule -s ${selinuxvariant} -i %{_datadir}/selinux/${selinuxvariant}/bitcoin.pp &> /dev/null || :
-done
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 8332
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 8333
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18332
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18333
-%{_sbindir}/fixfiles -R bitcoin-server restore &> /dev/null || :
-%{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin || :
-fi
+%systemd_post bitcoin-sv.service
+# # SELinux
+# if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
+# for selinuxvariant in %{selinux_variants}; do
+# 	%{_sbindir}/semodule -s ${selinuxvariant} -i %{_datadir}/selinux/${selinuxvariant}/bitcoin-sv.pp &> /dev/null || :
+# done
+# %{_sbindir}/semanage port -a -t bitcoin-sv_port_t -p tcp 8332
+# %{_sbindir}/semanage port -a -t bitcoin-sv_port_t -p tcp 8333
+# %{_sbindir}/semanage port -a -t bitcoin-sv_port_t -p tcp 18332
+# %{_sbindir}/semanage port -a -t bitcoin-sv_port_t -p tcp 18333
+# %{_sbindir}/fixfiles -R bitcoin-sv-server restore &> /dev/null || :
+# %{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin-sv || :
+# fi
 
 %posttrans server
 %{_bindir}/systemd-tmpfiles --create
 
 %preun server
-%systemd_preun bitcoin.service
+%systemd_preun bitcoin-sv.service
 
 %postun server
-%systemd_postun bitcoin.service
-# SELinux
-if [ $1 -eq 0 ]; then
-	if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
-	%{_sbindir}/semanage port -d -p tcp 8332
-	%{_sbindir}/semanage port -d -p tcp 8333
-	%{_sbindir}/semanage port -d -p tcp 18332
-	%{_sbindir}/semanage port -d -p tcp 18333
-	for selinuxvariant in %{selinux_variants}; do
-		%{_sbindir}/semodule -s ${selinuxvariant} -r bitcoin &> /dev/null || :
-	done
-	%{_sbindir}/fixfiles -R bitcoin-server restore &> /dev/null || :
-	[ -d %{_localstatedir}/lib/bitcoin ] && \
-		%{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin &> /dev/null || :
-	fi
-fi
+%systemd_postun bitcoin-sv.service
+# # SELinux
+# if [ $1 -eq 0 ]; then
+# 	if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
+# 	%{_sbindir}/semanage port -d -p tcp 8332
+# 	%{_sbindir}/semanage port -d -p tcp 8333
+# 	%{_sbindir}/semanage port -d -p tcp 18332
+# 	%{_sbindir}/semanage port -d -p tcp 18333
+# 	for selinuxvariant in %{selinux_variants}; do
+# 		%{_sbindir}/semodule -s ${selinuxvariant} -r bitcoin-sv &> /dev/null || :
+# 	done
+# 	%{_sbindir}/fixfiles -R bitcoin-sv-server restore &> /dev/null || :
+# 	[ -d %{_localstatedir}/lib/bitcoin-sv ] && \
+# 		%{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin-sv &> /dev/null || :
+# 	fi
+# fi
 
 %clean
 rm -rf %{buildroot}
@@ -281,31 +272,32 @@ rm -rf %{buildroot}
 
 %files server
 %defattr(-,root,root,-)
-%license COPYING db-%{bdbv}.NC-LICENSE
-%doc COPYING bitcoin.conf.example doc/README.md doc/REST-interface.md doc/bips.md doc/dnsseed-policy.md doc/files.md doc/reduce-traffic.md doc/release-notes.md doc/tor.md
-%attr(0755,root,root) %{_sbindir}/bitcoind
-%attr(0644,root,root) %{_tmpfilesdir}/bitcoin.conf
-%attr(0644,root,root) %{_unitdir}/bitcoin.service
-%dir %attr(0750,bitcoin,bitcoin) %{_sysconfdir}/bitcoin
-%dir %attr(0750,bitcoin,bitcoin) %{_localstatedir}/lib/bitcoin
-%config(noreplace) %attr(0600,root,root) %{_sysconfdir}/sysconfig/bitcoin
-%attr(0644,root,root) %{_datadir}/selinux/*/*.pp
-%attr(0644,root,root) %{_mandir}/man1/bitcoind.1*
+%license COPYING
+%doc COPYING bitcoin-sv.conf.example doc/README.md
+%attr(0755,root,root) %{_sbindir}/bitcoin-svd
+%attr(0644,root,root) %{_tmpfilesdir}/bitcoin-sv.conf
+%attr(0644,root,root) %{_unitdir}/bitcoin-sv.service
+%dir %attr(0750,bitcoin-sv,bitcoin-sv) %{_sysconfdir}/bitcoin-sv
+%dir %attr(0750,bitcoin-sv,bitcoin-sv) %{_localstatedir}/lib/bitcoin-sv
+%config(noreplace) %attr(0600,root,root) %{_sysconfdir}/sysconfig/bitcoin-sv
+# %attr(0644,root,root) %{_datadir}/selinux/*/*.pp
+# %attr(0644,root,root) %{_mandir}/man1/bitcoin-sv-cli.1.gz
+# %attr(0644,root,root) %{_mandir}/man1/bitcoin-sv-tx.1.gz
+# %attr(0644,root,root) %{_mandir}/man1/bitcoin-svd.1.gz
 
 %files utils
 %defattr(-,root,root,-)
 %license COPYING
-%doc COPYING bitcoin.conf.example doc/README.md
-%attr(0755,root,root) %{_bindir}/bitcoin-cli
-%attr(0755,root,root) %{_bindir}/bitcoin-tx
-%attr(0755,root,root) %{_bindir}/bench_bitcoin
-%attr(0644,root,root) %{_mandir}/man1/bitcoin-cli.1*
+%doc COPYING bitcoin-sv.conf.example doc/README.md
+%attr(0755,root,root) %{_bindir}/bitcoin-sv-cli
+%attr(0755,root,root) %{_bindir}/bitcoin-sv-tx
+%attr(0755,root,root) %{_bindir}/bench_bitcoin-sv
 
 
 
 %changelog
 * Fri Feb 26 2016 Alice Wonder <buildmaster@librelamp.com> - 0.12.0-2
-- Rename Qt package from bitcoin to bitcoin-core
+- Rename Qt package from bitcoin-sv to bitcoin-sv-core
 - Make building of the Qt package optional
 - When building the Qt package, default to Qt5 but allow building
 -  against Qt4
@@ -315,4 +307,4 @@ rm -rf %{buildroot}
 - Initial spec file for 0.12.0 release
 
 # This spec file is written from scratch but a lot of the packaging decisions are directly
-# based upon the 0.11.2 package spec file from https://www.ringingliberty.com/bitcoin/
+# based upon the 0.11.2 package spec file from https://www.ringingliberty.com/bitcoin-sv/

--- a/contrib/rpm/bitcoin.spec
+++ b/contrib/rpm/bitcoin.spec
@@ -198,6 +198,7 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/bitcoin-sv
 rm -f %{buildroot}%{_bindir}/test_*
 
 %check
+. /opt/rh/devtoolset-7/enable
 make check
 
 %post libs -p /sbin/ldconfig

--- a/contrib/rpm/bitcoin.spec
+++ b/contrib/rpm/bitcoin.spec
@@ -1,7 +1,7 @@
 # %global selinux_variants mls strict targeted
 
 Name:		bitcoin-sv
-Version:	1.0.1
+Version:	1.0.2
 Release:	1%{?dist}
 Summary:	Peer to Peer Cryptographic Currency
 

--- a/contrib/rpm/bitcoin.spec
+++ b/contrib/rpm/bitcoin.spec
@@ -127,16 +127,15 @@ make %{?_smp_mflags}
 make install DESTDIR=%{buildroot}
 
 mkdir -p -m755 %{buildroot}%{_sbindir}
+# rename bitcoin to bitcoin-sv as one can have both of them installed
 mv %{buildroot}%{_bindir}/bitcoind %{buildroot}%{_sbindir}/bitcoin-svd
 mv %{buildroot}%{_bindir}/bitcoin-cli %{buildroot}%{_bindir}/bitcoin-sv-cli
 mv %{buildroot}%{_bindir}/bitcoin-tx %{buildroot}%{_bindir}/bitcoin-sv-tx
 mv %{buildroot}%{_bindir}/bench_bitcoin %{buildroot}%{_bindir}/bench_bitcoin-sv
 mv %{buildroot}%{_bindir}/bitcoin-miner %{buildroot}%{_bindir}/bitcoin-sv-miner
 mv %{buildroot}%{_bindir}/bitcoin-seeder %{buildroot}%{_bindir}/bitcoin-sv-seeder
-# mv %{buildroot}%{_mandir}/man1/bitcoin-cli.1.gz %{buildroot}%{_mandir}/man1/bitcoin-sv-cli.1.gz
-# mv %{buildroot}%{_mandir}/man1/bitcoin-tx.1.gz %{buildroot}%{_mandir}/man1/bitcoin-sv-tx.1.gz
-# mv %{buildroot}%{_mandir}/man1/bitcoind.1.gz %{buildroot}%{_mandir}/man1/bitcoin-svd.1.gz
-
+# remove manual pages as they are for "bitcoin" name
+rm -rf %{buildroot}/usr/share/man/man1/bitcoin*
 
 # systemd stuff
 mkdir -p %{buildroot}%{_tmpfilesdir}
@@ -275,6 +274,8 @@ rm -rf %{buildroot}
 %license COPYING
 %doc COPYING bitcoin-sv.conf.example doc/README.md
 %attr(0755,root,root) %{_sbindir}/bitcoin-svd
+%attr(0755,root,root) %{_bindir}/bitcoin-sv-miner
+%attr(0755,root,root) %{_bindir}/bitcoin-sv-seeder
 %attr(0644,root,root) %{_tmpfilesdir}/bitcoin-sv.conf
 %attr(0644,root,root) %{_unitdir}/bitcoin-sv.service
 %dir %attr(0750,bitcoin-sv,bitcoin-sv) %{_sysconfdir}/bitcoin-sv

--- a/contrib/rpm/build.sh
+++ b/contrib/rpm/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cwd=$(dirname $0)
+yum -y install epel-release; yum -y install centos-release-scl git vim rpm-build rpmdevtools
+rpmdev-setuptree
+spectool -g -R ${cwd}/bitcoin.spec
+yum-builddep -y ${cwd}/bitcoin.spec
+rpmbuild -bb ${cwd}/bitcoin.spec


### PR DESCRIPTION
By reusing leftover spec file from original bitcoin I've managed to build bitcoin-sv v1.0.1 under CentOS 7 with factory-provided glibc and openssl. Required boost169 packages are available in `epel` repository.

I don't recommend installing it on the same system that has original bitcoin installed, that's why I've removed SELinux policies and manual pages as they were for original bitcoin and could (and probably will) conflict.