### PR TITLE
change the default value of '-maxscriptsizepolicy' from 10KB to 500KB to support larger script size being allowed by default

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -91,7 +91,7 @@ static const unsigned int DEFAULT_MAX_NONFINAL_MEMPOOL_SIZE = 50;
 /** Minimum feerate increase for mempool limiting **/
 static const CFeeRate MEMPOOL_FULL_FEE_INCREMENT(Amount(1000));
 /** Default for -maxscriptsizepolicy **/
-static const unsigned int DEFAULT_MAX_SCRIPT_SIZE_POLICY_AFTER_GENESIS = 10000;
+static const unsigned int DEFAULT_MAX_SCRIPT_SIZE_POLICY_AFTER_GENESIS = 500000;
 /** Default -maxmempoolsizedisk factor, maximum megabytes of total mempool disk usage as scaled -maxmempool */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE_DISK_FACTOR = 0;
 /** Default percentage of total mempool size (ram+disk) to use as max limit for CPFP transactions */


### PR DESCRIPTION
this is the corresponding pull-request of #201 