### PR TITLE
Included a missing header.

### DIFF
--- a/src/txn_util.h
+++ b/src/txn_util.h
@@ -8,6 +8,7 @@
 
 #include <shared_mutex>
 #include <unordered_set>
+#include <mutex>
 
 /**
  * A class for tracking TxIds.


### PR DESCRIPTION
The mutex header was missing from `txn_util.h`.