### PR TITLE
support Range header for rest block api

### DIFF
--- a/src/block_index.h
+++ b/src/block_index.h
@@ -880,6 +880,9 @@ public:
 
     std::unique_ptr<CForwardReadonlyStream> StreamSyncBlockFromDisk() const;
 
+    std::unique_ptr<CForwardReadonlyStream> StreamSyncPartialBlockFromDisk(
+                            uint64_t offset, uint64_t length) const;
+
     friend class CDiskBlockIndex;
 
     /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1312,6 +1312,8 @@ void writeBlockChunksAndUpdateMetadata(bool isHexEncoded, HTTPRequest &req,
                     try
                     {
                         std::string s = range_header.second;
+                        assert(s.find("bytes=") == 0);
+                        s.erase(0, 6);
                         std::string delimiter = "-";
                         std::string rs_s = s.substr(0, s.find(delimiter));
                         s.erase(0, s.find(delimiter) + delimiter.length());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1277,18 +1277,29 @@ void writeBlockChunksAndUpdateMetadata(bool isHexEncoded, HTTPRequest &req,
                                        CBlockIndex& blockIndex, const std::string& rpcReqId,
                                        bool processedInBatch, const RetFormat& rf)
 {
-    auto stream = blockIndex.StreamSyncBlockFromDisk();
-    if (!stream) 
-    {
-        // Block not found on disk. This could be because we have the block
-        // header in our index but don't have the block (for example if a
-        // non-whitelisted node sends us an unrequested long chain of valid
-        // blocks, we add the headers to our index, but don't accept the block).
-        throw block_parse_error(blockIndex.GetBlockHash().GetHex() + " not found on disk");
-    }
-
     CDiskBlockMetaData metadata = blockIndex.GetDiskBlockMetaData();
     bool hasDiskBlockMetaData = !metadata.diskDataHash.IsNull();
+    
+    std::pair<bool, std::string> range_header = req.GetHeader("Range");
+    bool hasRangeHeader = range_header.first;
+
+    uint64_t offset;
+    uint64_t content_length;
+    std::unique_ptr<CForwardReadonlyStream> stream;
+
+    if (!hasDiskBlockMetaData && hasRangeHeader) {
+        stream = blockIndex.StreamSyncBlockFromDisk();
+        do
+        {
+            auto chunk = stream->Read(4096);
+            metadata.diskDataSize += chunk.Size();
+        } while (!stream->EndOfStream());
+
+        blockIndex.SetBlockIndexFileMetaDataIfNotSet(metadata, mapBlockIndex);
+
+        metadata = blockIndex.GetDiskBlockMetaData();
+        hasDiskBlockMetaData = !metadata.diskDataHash.IsNull();
+    }
 
     switch (rf)
     {
@@ -1296,7 +1307,45 @@ void writeBlockChunksAndUpdateMetadata(bool isHexEncoded, HTTPRequest &req,
         {
             if (hasDiskBlockMetaData)
             {
-                req.WriteHeader("Content-Length", std::to_string(metadata.diskDataSize));
+                if (hasRangeHeader)
+                {
+                    try
+                    {
+                        std::string s = range_header.second;
+                        std::string delimiter = "-";
+                        std::string rs_s = s.substr(0, s.find(delimiter));
+                        s.erase(0, s.find(delimiter) + delimiter.length());
+                        std::string re_s = s;
+
+                        uint64_t rs = std::stoll(rs_s);
+                        uint64_t re = std::stoll(re_s);
+
+                        if (rs > re)
+                        {
+                            throw block_parse_error("Invalid Range parameter, start > end");
+                        }
+                        if (rs >= metadata.diskDataSize)
+                        {
+                            throw block_parse_error("Invalid Range parameter, start >= data_size");
+                        }
+
+                        offset = rs;
+
+                        uint64_t remain = metadata.diskDataSize - offset;
+                        content_length = std::min(remain, re - rs + 1);
+
+                        req.WriteHeader("Content-Length", std::to_string(content_length));
+                        req.WriteHeader("Content-Range", "bytes " + std::to_string(offset) + "-" + 
+                            std::to_string(content_length - 1) + "/" + std::to_string(metadata.diskDataSize));
+                    }
+                    catch (...) {
+                        throw block_parse_error("Invalid Range parameter.");
+                    }
+                }
+                else
+                {
+                    req.WriteHeader("Content-Length", std::to_string(metadata.diskDataSize));
+                }
             }
             req.WriteHeader("Content-Type", "application/octet-stream");
             break;
@@ -1332,6 +1381,23 @@ void writeBlockChunksAndUpdateMetadata(bool isHexEncoded, HTTPRequest &req,
     if (!rpcReqId.empty())
     {
         req.WriteReplyChunk("{\"result\": \"");
+    }
+
+    if (hasRangeHeader)
+    {
+        stream = blockIndex.StreamSyncPartialBlockFromDisk(offset, content_length);
+    }
+    else
+    {
+        stream = blockIndex.StreamSyncBlockFromDisk();
+    }
+    if (!stream) 
+    {
+        // Block not found on disk. This could be because we have the block
+        // header in our index but don't have the block (for example if a
+        // non-whitelisted node sends us an unrequested long chain of valid
+        // blocks, we add the headers to our index, but don't accept the block).
+        throw block_parse_error(blockIndex.GetBlockHash().GetHex() + " not found on disk");
     }
 
     CHash256 hasher;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1284,67 +1284,55 @@ void writeBlockChunksAndUpdateMetadata(bool isHexEncoded, HTTPRequest &req,
     bool hasRangeHeader = range_header.first;
 
     uint64_t offset;
-    uint64_t content_length;
+    uint64_t contentLen;
     std::unique_ptr<CForwardReadonlyStream> stream;
-
-    if (!hasDiskBlockMetaData && hasRangeHeader) {
-        stream = blockIndex.StreamSyncBlockFromDisk();
-        do
-        {
-            auto chunk = stream->Read(4096);
-            metadata.diskDataSize += chunk.Size();
-        } while (!stream->EndOfStream());
-
-        blockIndex.SetBlockIndexFileMetaDataIfNotSet(metadata, mapBlockIndex);
-
-        metadata = blockIndex.GetDiskBlockMetaData();
-        hasDiskBlockMetaData = !metadata.diskDataHash.IsNull();
-    }
 
     switch (rf)
     {
         case RF_BINARY:
         {
-            if (hasDiskBlockMetaData)
+            if (hasRangeHeader)
             {
-                if (hasRangeHeader)
+                try
                 {
-                    try
+                    std::string s = range_header.second;
+                    if (s.find("bytes=") != 0)
                     {
-                        std::string s = range_header.second;
-                        assert(s.find("bytes=") == 0);
-                        s.erase(0, 6);
-                        std::string delimiter = "-";
-                        std::string rs_s = s.substr(0, s.find(delimiter));
-                        s.erase(0, s.find(delimiter) + delimiter.length());
-                        std::string re_s = s;
-
-                        uint64_t rs = std::stoll(rs_s);
-                        uint64_t re = std::stoll(re_s);
-
-                        if (rs > re)
-                        {
-                            throw block_parse_error("Invalid Range parameter, start > end");
-                        }
-                        if (rs >= metadata.diskDataSize)
-                        {
-                            throw block_parse_error("Invalid Range parameter, start >= data_size");
-                        }
-
-                        offset = rs;
-
-                        uint64_t remain = metadata.diskDataSize - offset;
-                        content_length = std::min(remain, re - rs + 1);
-
-                        req.WriteHeader("Content-Length", std::to_string(content_length));
-                        req.WriteHeader("Content-Range", "bytes " + std::to_string(offset) + "-" + 
-                            std::to_string(content_length - 1) + "/" + std::to_string(metadata.diskDataSize));
+                        throw block_parse_error("Invalid Range header format, should starts with 'bytes='");
                     }
-                    catch (...) {
-                        throw block_parse_error("Invalid Range parameter.");
+                    s.erase(0, 6);
+                    std::string delimiter = "-";
+                    std::string rs_s = s.substr(0, s.find(delimiter));
+                    s.erase(0, s.find(delimiter) + delimiter.length());
+                    std::string re_s = s;
+
+                    uint64_t rs = std::stoll(rs_s);
+                    uint64_t re = std::stoll(re_s);
+
+                    if (rs > re)
+                    {
+                        throw block_parse_error("Invalid Range parameter, start > end");
                     }
+                    if (rs >= metadata.diskDataSize)
+                    {
+                        throw block_parse_error("Invalid Range parameter, start >= data_size");
+                    }
+
+                    offset = rs;
+
+                    uint64_t remain = metadata.diskDataSize - offset;
+                    contentLen = std::min(remain, re - rs + 1);
+                    std::string totalLen = hasDiskBlockMetaData ? std::to_string(metadata.diskDataSize) : "*";
+
+                    req.WriteHeader("Content-Length", std::to_string(contentLen));
+                    req.WriteHeader("Content-Range", "bytes " + std::to_string(offset) + "-" + 
+                        std::to_string(contentLen - 1) + "/" + totalLen);
                 }
-                else
+                catch (...) {
+                    throw block_parse_error("Invalid Range parameter.");
+                }
+            } else {
+                if (hasDiskBlockMetaData)
                 {
                     req.WriteHeader("Content-Length", std::to_string(metadata.diskDataSize));
                 }
@@ -1376,7 +1364,11 @@ void writeBlockChunksAndUpdateMetadata(bool isHexEncoded, HTTPRequest &req,
 
     if (!processedInBatch)
     {
-        req.StartWritingChunks(HTTP_OK);
+        if (hasRangeHeader) {
+            req.StartWritingChunks(HTTP_PARTIAL_CONTENT);
+        } else {
+            req.StartWritingChunks(HTTP_OK);
+        }
     }
 
     // RPC requests have additional layer around the actual response 
@@ -1387,7 +1379,7 @@ void writeBlockChunksAndUpdateMetadata(bool isHexEncoded, HTTPRequest &req,
 
     if (hasRangeHeader)
     {
-        stream = blockIndex.StreamSyncPartialBlockFromDisk(offset, content_length);
+        stream = blockIndex.StreamSyncPartialBlockFromDisk(offset, contentLen);
     }
     else
     {

--- a/src/rpc/http_protocol.h
+++ b/src/rpc/http_protocol.h
@@ -8,6 +8,7 @@
 // HTTP status codes
 enum HTTPStatusCode {
     HTTP_OK = 200,
+    HTTP_PARTIAL_CONTENT = 206,
     HTTP_BAD_REQUEST = 400,
     HTTP_UNAUTHORIZED = 401,
     HTTP_FORBIDDEN = 403,

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -37,6 +37,15 @@ def http_get_call(host, port, path, response_object=0):
 
     return conn.getresponse().read().decode('utf-8')
 
+def http_get_call_with_headers(host, port, path, headers, response_object=0):
+    conn = http.client.HTTPConnection(host, port)
+    conn.request('GET', path, None, headers)
+
+    if response_object:
+        return conn.getresponse()
+
+    return conn.getresponse().read().decode('utf-8')
+
 # allows simple http post calls with a request body
 
 
@@ -251,6 +260,13 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(response.status, 200)
         assert_greater_than(int(response.getheader('content-length')), 80)
         response_str = response.read()
+
+        # get binary block with range
+        response = http_get_call_with_headers(
+            url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': '10-29'}, True)
+        assert_equal(response_str[10:30], response.read())
+        assert_equal(response.status, 200)
+        assert_equal(int(response.getheader('content-length')), 20)
 
         # compare with block header
         response_header = http_get_call(

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -263,7 +263,7 @@ class RESTTest (BitcoinTestFramework):
 
         # get binary block with range
         response = http_get_call_with_headers(
-            url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': '10-29'}, True)
+            url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': 'bytes=10-29'}, True)
         assert_equal(response_str[10:30], response.read())
         assert_equal(response.status, 200)
         assert_equal(int(response.getheader('content-length')), 20)

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -265,8 +265,26 @@ class RESTTest (BitcoinTestFramework):
         response = http_get_call_with_headers(
             url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': 'bytes=10-29'}, True)
         assert_equal(response_str[10:30], response.read())
-        assert_equal(response.status, 200)
+        assert_equal(response.status, 206)
         assert_equal(int(response.getheader('content-length')), 20)
+
+        # get binary block with invalid range parameters
+
+        # range overlapping
+        response = http_get_call_with_headers(
+            url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': 'bytes=29-10'}, True)
+        assert_equal(response.status, 404)
+
+        # range out of data size
+        response = http_get_call_with_headers(
+            url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': 'bytes=0-999999'}, True)
+        assert_equal(response.status, 404)
+
+        # invalid format
+        response = http_get_call_with_headers(
+            url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': '10-29'}, True)
+        assert_equal(response.status, 404)
+
 
         # compare with block header
         response_header = http_get_call(

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -275,11 +275,6 @@ class RESTTest (BitcoinTestFramework):
             url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': 'bytes=29-10'}, True)
         assert_equal(response.status, 404)
 
-        # range out of data size
-        response = http_get_call_with_headers(
-            url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': 'bytes=0-999999'}, True)
-        assert_equal(response.status, 404)
-
         # invalid format
         response = http_get_call_with_headers(
             url.hostname, url.port, '/rest/block/' + bb_hash + self.FORMAT_SEPARATOR + "bin", {'Range': '10-29'}, True)


### PR DESCRIPTION
Hi, folks. This is an implementation of HTTP Range header for the `/rest/block/...bin` api. As the block size got bigger and bigger, we met some problems in downloading the entire block data from the node. The connection keeps dropping when downloading a 1G~3G block. While we trying to improve our network, a HTTP Range header support would be a nice fix for this.

For example, a `Range: 0-1024000` header can be set in the request to download the first 1M data of block. As well any other part. It effectively reduces the failure rate.

The code works fine in our production. I'm not a C++ professional, so it's just a suggestion on how to implement this feature.