### PR TITLE
Fixes for ubuntu_22_04

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -657,9 +657,9 @@ CService HTTPRequest::GetPeer() {
     CService peer;
     if (con) {
         // evhttp retains ownership over returned address string
-        const char *address = "";
+        char *address = "";
         uint16_t port = 0;
-        evhttp_connection_get_peer(con, (char **)&address, &port);
+        evhttp_connection_get_peer(con, &address, &port);
         peer = LookupNumeric(address, port);
     }
     return peer;

--- a/src/txn_recent_rejects.cpp
+++ b/src/txn_recent_rejects.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "txn_recent_rejects.h"
+#include <mutex>
 
 CTxnRecentRejects::CTxnRecentRejects() {
     // Create a bloom filter

--- a/src/txn_util.h
+++ b/src/txn_util.h
@@ -8,6 +8,7 @@
 
 #include <shared_mutex>
 #include <unordered_set>
+#include <mutex>
 
 /**
  * A class for tracking TxIds.


### PR DESCRIPTION
There are compilation problems on ubuntu 22.04 with the version of g++ below.

root@bc950ee3ecdf:/bitcoin/bitcoin-sv# g++ --version
g++ (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
