### PR TITLE
wallet: add rescanblockchain RPC and coverage

### DIFF
--- a/src/rpc/client_utils.cpp
+++ b/src/rpc/client_utils.cpp
@@ -28,7 +28,7 @@ public:
  *
  * @note Parameter indexes start from 0.
  */
-static const std::array<CRPCConvertParam, 120> vRPCConvertParams  //NOLINT(cert-err58-cpp)
+static const std::array<CRPCConvertParam, 122> vRPCConvertParams  //NOLINT(cert-err58-cpp)
 {{
     {"setmocktime", 0, "timestamp"},
     {"generate", 0, "nblocks"},
@@ -111,6 +111,8 @@ static const std::array<CRPCConvertParam, 120> vRPCConvertParams  //NOLINT(cert-
     {"getblockstatsbyheight", 1, "stats"},
     {"pruneblockchain", 0, "height"},
     {"keypoolrefill", 0, "newsize"},
+    {"rescanblockchain", 0, "start_height"},
+    {"rescanblockchain", 1, "stop_height"},
     {"getrawmempool", 0, "verbose"},
     {"prioritisetransaction", 1, "priority_delta"},
     {"prioritisetransaction", 2, "fee_delta"},
@@ -334,4 +336,3 @@ int AppInitRPC(int argc, char *argv[], const std::string& usage_format, const st
     }
     return CONTINUE_EXECUTION;
 }
-

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3068,6 +3068,95 @@ static UniValue resendwallettransactions(const Config&,
     return result;
 }
 
+static UniValue rescanblockchain(const Config&, const JSONRPCRequest& request)
+{
+    CWallet *const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    if (request.fHelp || request.params.size() > 2) {
+        throw std::runtime_error(
+            "rescanblockchain ( start_height stop_height )\n"
+            "\nRescan blockchain for wallet transactions.\n"
+            "\nArguments:\n"
+            "1. start_height    (numeric, optional, default=0) Block height "
+            "where rescan starts.\n"
+            "2. stop_height     (numeric, optional, default=chain tip) Block "
+            "height where rescan stops.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"start_height\": n,    (numeric) Rescan start height\n"
+            "  \"stop_height\": n      (numeric) Rescan stop height\n"
+            "}\n"
+            "\nExamples:\n" +
+            HelpExampleCli("rescanblockchain", "") +
+            HelpExampleCli("rescanblockchain", "100000") +
+            HelpExampleCli("rescanblockchain", "100000 120000") +
+            HelpExampleRpc("rescanblockchain", "") +
+            HelpExampleRpc("rescanblockchain", "100000, 120000"));
+    }
+
+    int start_height = 0;
+    if (request.params.size() > 0 && !request.params[0].isNull()) {
+        RPCTypeCheckArgument(request.params[0], UniValue::VNUM);
+        start_height = request.params[0].get_int();
+    }
+
+    int stop_height = 0;
+    const CBlockIndex *start_block = nullptr;
+    const CBlockIndex *stop_block = nullptr;
+    {
+        LOCK(cs_main);
+
+        if (start_height < 0 || start_height > chainActive.Height()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Block height out of range");
+        }
+
+        stop_height = chainActive.Height();
+        if (request.params.size() > 1 && !request.params[1].isNull()) {
+            RPCTypeCheckArgument(request.params[1], UniValue::VNUM);
+            stop_height = request.params[1].get_int();
+        }
+
+        if (stop_height < 0 || stop_height > chainActive.Height()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Block height out of range");
+        }
+
+        if (start_height > stop_height) {
+            throw JSONRPCError(
+                RPC_INVALID_PARAMETER,
+                "stop_height must be greater than or equal to start_height");
+        }
+
+        start_block = chainActive[start_height];
+        stop_block = chainActive[stop_height];
+    }
+
+    uiInterface.InitMessage(_("Rescanning..."));
+    LogPrintf("Rescanning wallet %s from block %d to %d...\n",
+              pwallet->GetName(), start_height, stop_height);
+
+    const CBlockIndex *const scanned_block =
+        pwallet->ScanForWalletTransactions(start_block, true, stop_block);
+    pwallet->MarkDirty();
+    pwallet->ReacceptWalletTransactions();
+
+    if (scanned_block == nullptr ||
+        scanned_block->GetHeight() > start_block->GetHeight()) {
+        throw JSONRPCError(
+            RPC_MISC_ERROR,
+            "Rescan failed for some blocks. Your node may be pruned.");
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.push_back(Pair("start_height", start_height));
+    result.push_back(Pair("stop_height", stop_height));
+    return result;
+}
+
 static UniValue listunspent(const Config &config,
                             const JSONRPCRequest &request) {
     CWallet *const pwallet = GetWalletForJSONRPCRequest(request);
@@ -3516,7 +3605,7 @@ void RegisterWalletRPCCommands(CRPCTable& t)
         return;
 
     // clang-format off
-    static const std::array<CRPCCommand, 39> commands{{
+    static const std::array<CRPCCommand, 40> commands{{
         //  category            name                        actor (function)          okSafeMode
         //  ------------------- ------------------------    ----------------------    ----------
         { "rawtransactions",    "fundrawtransaction",       fundrawtransaction,       false,  {"hexstring","options"} },
@@ -3548,6 +3637,7 @@ void RegisterWalletRPCCommands(CRPCTable& t)
         { "wallet",             "listwallets",              listwallets,              true,   {} },
         { "wallet",             "lockunspent",              lockunspent,              true,   {"unlock","transactions"} },
         { "wallet",             "move",                     movecmd,                  false,  {"fromaccount","toaccount","amount","minconf","comment"} },
+        { "wallet",             "rescanblockchain",         rescanblockchain,         false,  {"start_height","stop_height"} },
         { "wallet",             "sendfrom",                 sendfrom,                 false,  {"fromaccount","toaddress","amount","minconf","comment","comment_to"} },
         { "wallet",             "sendmany",                 sendmany,                 false,  {"fromaccount","amounts","minconf","comment","subtractfeefrom"} },
         { "wallet",             "sendtoaddress",            sendtoaddress,            false,  {"address","amount","comment","comment_to","subtractfeefromamount"} },

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -541,6 +541,59 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup) {
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(rescan_range, TestChain100Setup) {
+    LOCK(cs_main);
+
+    // Cap last block file size, and mine new block in a new block file.
+    CBlockIndex *oldTip = chainActive.Tip();
+    pBlockFileInfoStore
+        ->GetBlockFileInfo(oldTip->GetBlockPos().File())
+        ->AddNewBlock(1, 1, DEFAULT_PREFERRED_BLOCKFILE_SIZE);
+    CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+    CBlockIndex *newTip = chainActive.Tip();
+
+    // Verify bounded rescans respect stop height.
+    {
+        CWallet wallet(Params());
+        LOCK(wallet.cs_wallet);
+        wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        BOOST_CHECK_EQUAL(
+            oldTip, wallet.ScanForWalletTransactions(oldTip, false, oldTip));
+        BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), 50 * COIN);
+    }
+
+    {
+        CWallet wallet(Params());
+        LOCK(wallet.cs_wallet);
+        wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        BOOST_CHECK_EQUAL(
+            oldTip, wallet.ScanForWalletTransactions(oldTip, false, newTip));
+        BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), 100 * COIN);
+    }
+
+    // Prune older block file and verify bounded rescans fail or partially
+    // succeed as expected.
+    UnlinkPrunedFiles({oldTip->GetBlockPos().File()});
+
+    {
+        CWallet wallet(Params());
+        LOCK(wallet.cs_wallet);
+        wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        BOOST_CHECK(wallet.ScanForWalletTransactions(oldTip, false, oldTip) ==
+                    nullptr);
+        BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), Amount(0));
+    }
+
+    {
+        CWallet wallet(Params());
+        LOCK(wallet.cs_wallet);
+        wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        BOOST_CHECK_EQUAL(
+            newTip, wallet.ScanForWalletTransactions(oldTip, false, newTip));
+        BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), 50 * COIN);
+    }
+}
+
 // Verify importwallet RPC starts rescan at earliest block with timestamp
 // greater or equal than key birthday. Previously there was a bug where
 // importwallet RPC would start the scan at the latest block with timestamp less

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1736,8 +1736,9 @@ void CWalletTx::GetAmounts(std::list<COutputEntry> &listReceived,
  * before CWallet::nTimeFirstKey). Returns null if there is no such range, or
  * the range doesn't include chainActive.Tip().
  */
-const CBlockIndex *CWallet::ScanForWalletTransactions(const CBlockIndex *pindexStart,
-                                                bool fUpdate) {
+const CBlockIndex *CWallet::ScanForWalletTransactions(
+    const CBlockIndex *pindexStart, bool fUpdate,
+    const CBlockIndex *pindexStop) {
     LOCK2(cs_main, cs_wallet);
 
     int64_t nNow = GetTime();
@@ -1752,7 +1753,8 @@ const CBlockIndex *CWallet::ScanForWalletTransactions(const CBlockIndex *pindexS
         pindex = chainActive.Next(pindex);
     }
 
-    while (pindex) {
+    while (pindex &&
+           (!pindexStop || pindex->GetHeight() <= pindexStop->GetHeight())) {
 
         auto stream = pindex->GetDiskBlockStreamReader();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -910,8 +910,9 @@ public:
     bool AddToWalletIfInvolvingMe(const CTransactionRef &tx,
                                   const CBlockIndex *pIndex, int posInBlock,
                                   bool fUpdate);
-    const CBlockIndex *ScanForWalletTransactions(const CBlockIndex *pindexStart,
-                                           bool fUpdate = false);
+    const CBlockIndex *ScanForWalletTransactions(
+        const CBlockIndex *pindexStart, bool fUpdate = false,
+        const CBlockIndex *pindexStop = nullptr);
     void ReacceptWalletTransactions();
     // ResendWalletTransactionsBefore may only be called if
     // fBroadcastTransactions!

--- a/test/functional/rescanblockchain.py
+++ b/test/functional/rescanblockchain.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Bitcoin Association
+# Distributed under Open BSV software license, see accompanying file LICENSE.
+"""Test rescanblockchain wallet RPC and CLI."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class RescanBlockchainTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def run_test(self):
+        self.log.info("mine spendable balance")
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        label = "rescanned"
+        address1 = self.nodes[0].getnewaddress()
+        address2 = self.nodes[0].getnewaddress()
+        privkey1 = self.nodes[0].dumpprivkey(address1)
+        privkey2 = self.nodes[0].dumpprivkey(address2)
+
+        txid1 = self.nodes[0].sendtoaddress(address1, Decimal("1.0"))
+        block1_hash = self.nodes[0].generate(1)[0]
+        height1 = self.nodes[0].getblock(block1_hash)["height"]
+
+        txid2 = self.nodes[0].sendtoaddress(address2, Decimal("2.0"))
+        block2_hash = self.nodes[0].generate(1)[0]
+        height2 = self.nodes[0].getblock(block2_hash)["height"]
+
+        self.sync_all()
+
+        self.nodes[1].importprivkey(privkey1, label, False)
+        self.nodes[1].importprivkey(privkey2, label, False)
+        assert_equal(self.nodes[1].getbalance(label, 0, True), Decimal("0"))
+
+        node1_pid = self.nodes[1].process.pid
+
+        self.log.info("bounded rescan through bitcoin-cli")
+        assert_equal(
+            self.nodes[1].cli.rescanblockchain(height1, height1),
+            {"start_height": height1, "stop_height": height1})
+        assert_equal(self.nodes[1].process.pid, node1_pid)
+        assert_equal(self.nodes[1].getbalance(label, 0, True), Decimal("1.0"))
+
+        txids = {tx["txid"] for tx in self.nodes[1].listtransactions(label, 100, 0, True)}
+        assert_equal(txid1 in txids, True)
+        assert_equal(txid2 in txids, False)
+
+        self.log.info("second bounded rescan through RPC")
+        assert_equal(
+            self.nodes[1].rescanblockchain(height2, height2),
+            {"start_height": height2, "stop_height": height2})
+        assert_equal(self.nodes[1].process.pid, node1_pid)
+        assert_equal(self.nodes[1].getbalance(label, 0, True), Decimal("3.0"))
+
+        txids = {tx["txid"] for tx in self.nodes[1].listtransactions(label, 100, 0, True)}
+        assert_equal(txids.issuperset({txid1, txid2}), True)
+
+        self.log.info("default full-range rescan through bitcoin-cli")
+        assert_equal(
+            self.nodes[1].cli.rescanblockchain(),
+            {
+                "start_height": 0,
+                "stop_height": self.nodes[1].getblockcount(),
+            })
+        assert_equal(self.nodes[1].process.pid, node1_pid)
+        assert_equal(self.nodes[1].getbalance(label, 0, True), Decimal("3.0"))
+
+        self.log.info("parameter validation")
+        assert_raises_rpc_error(
+            -8,
+            "Block height out of range",
+            self.nodes[1].rescanblockchain,
+            -1)
+        assert_raises_rpc_error(
+            -8,
+            "Block height out of range",
+            self.nodes[1].rescanblockchain,
+            self.nodes[1].getblockcount() + 1)
+        assert_raises_rpc_error(
+            -8,
+            "stop_height must be greater than or equal to start_height",
+            self.nodes[1].rescanblockchain,
+            height2,
+            height1)
+
+
+if __name__ == '__main__':
+    RescanBlockchainTest().main()


### PR DESCRIPTION
Something that is not needed often, but very handy to have when it is needed.

Waiting for a full rescan takes a very long time. Having to restart a busy full node to run -rescan also takes a very long time.

This adds the cli command rescanblockchain which does not require restarting the node and can scan only small sections of the chain.

Borrows heavily from [cores](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/rpc/transactions.cpp#L821) implementation